### PR TITLE
Add automated release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Sodium Translations/**
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Bump Version
+        id: bump
+        uses: anothrNick/github-tag-action@d77194f92b4ca48b05df5c20709984535a9cd6e0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+
+
+  release:
+    name: Build Resource Pack
+    runs-on: ubuntu-latest
+
+    needs:
+      - version
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Create Resource Pack File
+        run: (cd Sodium\ Translations && zip -r "../Sodium Translations.zip" *)
+
+      - name: Generate Checksum
+        run: sha1sum "Sodium Translations.zip" | cut -d " " -f 1 > "Sodium Translations.zip.sha1sum"
+      
+      - name: Store Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Resource Pack
+          path: Sodium\ Translations.zip*
+      
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
+        with:
+          tag_name: ${{ needs.version.outputs.tag }}
+          generate_release_notes: true
+          files: Sodium\ Translations.zip*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - l10n_main
     paths:
       - Sodium Translations/**
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Unofficial Sodium Translations
 
-## Overview
-
 This repository hosts unofficial translations for [**Sodium**](https://github.com/CaffeineMC/sodium-fabric), a Minecraft mod designed to improve frame rates and reduce micro-stutter. Please see [the FAQ](#FAQ) for **F**requently **A**sked **Q**uestions and supplimentary information about the project.
 
 ## Installation
 
-### Resource pack
+All translations in this repository are available as a resource pack, which you can install like any other resource pack. Simply grab the latest release and put it into your resource pack folder. You can find the latest release here: [Download latest release](https://github.com/Madis0/sodium-fabric-translations/releases/latest/download/Sodium.Translations.zip).
 
-[Download the resource pack](https://kinolien.github.io/gitzip/?download=https://github.com/Madis0/sodium-fabric-translations/tree/l10n_main/Sodium%20Translations), import it and activate it in-game. If you don't see your translations on it yet, download again later.
-
+Please note that it might take a while for changes to be synced to this repository. If you don't see the most recent translations, please check back later for a new release.
 
 ## Translating
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Unofficial Sodium Translations
 
+<img align="right" src="Sodium Translations/pack.png" alt="Unofficial Sodium Translations" title="Unofficial Sodium Translations" height="72" />
+
 This repository hosts unofficial translations for [**Sodium**](https://github.com/CaffeineMC/sodium-fabric), a Minecraft mod designed to improve frame rates and reduce micro-stutter. Please see [the FAQ](#FAQ) for **F**requently **A**sked **Q**uestions and supplimentary information about the project.
 
 ## Installation


### PR DESCRIPTION
This PR adds a GitHub Action workflow which automatically bumps the version in semantic versioning and creates a release in GitHub with the installable resource pack .zip-file and a SHA1 checksum file appended.

This only affects pushes that change the resource pack files inside the `Sodium Translations` folder.

Also, this updates the README to contain the current `pack.png` image for eyecandy reasons and also updates the instructions to the URL of the latest GitHub release.

![grafik](https://user-images.githubusercontent.com/6287093/235448181-187cb9a0-f61a-44c8-9c2b-0e9bb39dc9a2.png)
